### PR TITLE
修改expired方法检查依据

### DIFF
--- a/lib/shanbay_oauth2.js
+++ b/lib/shanbay_oauth2.js
@@ -75,7 +75,7 @@ ShanbayOauth.prototype.has_token = function(){
 
 ShanbayOauth.prototype.expired = function(){
     var expired_at = localStorage.expired_at;
-    return expired_at == undefined || expired_at < new Date();
+    return expired_at == undefined || new Date(expired_at) < new Date();
 }
 
 ShanbayOauth.prototype.token_valid = function(){


### PR DESCRIPTION
默认存储的时候是直接存储了一个Date对象[第45行]，也就是存储的Date对象的字符串格式。然后比较是不是过期的时候，直接跟Date对象作比较，也就是比较Date对象的toValue方法得到的数字。不管有没有过期，这样得到的一直是false。